### PR TITLE
TICKET-04 User should be able to enter an empty task

### DIFF
--- a/src/integration/tests/firstTest.test.jsx
+++ b/src/integration/tests/firstTest.test.jsx
@@ -65,6 +65,20 @@ describe("Testes", () => {
     expect(screen.queryByTestId(`TASK_CONTAINER_${taskMsg}`)).not.toBeInTheDocument();
   });
 
+  it('User should not be able to enter an empty task.', () => {
+    render(<App />);
+    const taskMsg = '';
+
+    const input = screen.getByTestId('INPUT_TASK');
+    userEvent.clear(input);
+    userEvent.type(input, taskMsg);
+    const addTask = screen.getByTestId('ADD_BUTTON');
+    userEvent.click(addTask);
+   
+    expect(screen.queryByTestId(`TASK_CONTAINER_${taskMsg}`)).toBeInTheDocument();
+
+  });
+  
   it('Patient should be able to open task details.', () => {
     render(<App />);
     const taskMsg = `testes de integração ${Date.now()}`;
@@ -84,6 +98,5 @@ describe("Testes", () => {
     expect(screen.getByTestId('BACK_BUTTON')).toHaveTextContent(backButton);
 
   });
-
 
 });

--- a/src/integration/tests/firstTest.test.jsx
+++ b/src/integration/tests/firstTest.test.jsx
@@ -65,7 +65,7 @@ describe("Testes", () => {
     expect(screen.queryByTestId(`TASK_CONTAINER_${taskMsg}`)).not.toBeInTheDocument();
   });
 
-  it('User should not be able to enter an empty task.', () => {
+  it('User should be able to enter an empty task.', () => {
     render(<App />);
     const taskMsg = '';
 


### PR DESCRIPTION
Adding test to check that the system accept the insert of an empty task.

![image](https://user-images.githubusercontent.com/17017218/223533563-88a9fe07-33fc-40a3-a60e-a071507a3abc.png)


Obs: This branch is depends on TICKET-02, link:
https://github.com/alaninfo23/tasklist-react/pull/4
Please review only the commit:
'Add test case: User should be able to enter an empty task'